### PR TITLE
feat: link portal subscription actions

### DIFF
--- a/app/(site)/portal/page.tsx
+++ b/app/(site)/portal/page.tsx
@@ -1,12 +1,41 @@
 
 'use client';
 import { useState } from 'react';
+
 export default function Portal() {
-  const [status,setStatus]=useState<'active'|'paused'>('active');
-  const nextDate = '2025-09-01'; // mock
-  function pause(){ setStatus('paused'); /* TODO: POST /api/subscriptions/pause */ }
-  function resume(){ setStatus('active'); /* TODO: POST /api/subscriptions/pause */ }
-  function skip(){ alert('Entrega saltada (demo)'); /* TODO: POST /api/subscriptions/skip */ }
+  // TODO: obtener datos reales de la suscripción actual
+  const subscriptionId = 'demo-subscription';
+  const [status, setStatus] = useState<'active' | 'paused'>('active');
+  const [nextDate, setNextDate] = useState('2025-09-01'); // mock inicial
+
+  async function pause() {
+    await fetch('/api/subscriptions/pause', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subscriptionId, action: 'pause' }),
+    });
+    setStatus('paused');
+  }
+
+  async function resume() {
+    await fetch('/api/subscriptions/pause', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subscriptionId, action: 'resume' }),
+    });
+    setStatus('active');
+  }
+
+  async function skip() {
+    const res = await fetch('/api/subscriptions/skip', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subscriptionId }),
+    });
+    const data = await res.json();
+    if (data.next_renewal_date) setNextDate(data.next_renewal_date);
+    alert('Entrega saltada');
+  }
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Mi suscripción</h1>

--- a/app/api/subscriptions/pause/route.ts
+++ b/app/api/subscriptions/pause/route.ts
@@ -1,6 +1,14 @@
 
 import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseServer';
+
 export async function POST(req: NextRequest) {
-  // TODO: update subscriptions.status='paused'
-  return NextResponse.json({ ok: true });
+  const { subscriptionId, action } = await req.json();
+  const status = action === 'pause' ? 'paused' : 'active';
+  const supabase = supabaseAdmin();
+  await supabase
+    .from('subscriptions')
+    .update({ status })
+    .eq('id', subscriptionId);
+  return NextResponse.json({ ok: true, status });
 }

--- a/app/api/subscriptions/skip/route.ts
+++ b/app/api/subscriptions/skip/route.ts
@@ -1,6 +1,40 @@
 
 import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseServer';
+
 export async function POST(req: NextRequest) {
-  // TODO: insertar en subscription_skips y mover next_renewal_date
-  return NextResponse.json({ ok: true });
+  const { subscriptionId } = await req.json();
+  const supabase = supabaseAdmin();
+  const { data: subscription } = await supabase
+    .from('subscriptions')
+    .select('next_renewal_date, frequency')
+    .eq('id', subscriptionId)
+    .single();
+
+  if (!subscription) {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const { next_renewal_date, frequency } = subscription as {
+    next_renewal_date: string;
+    frequency: string;
+  };
+
+  await supabase
+    .from('subscription_skips')
+    .insert({ subscription_id: subscriptionId, scheduled_date: next_renewal_date });
+
+  const date = new Date(next_renewal_date);
+  let days = 7;
+  if (frequency === 'biweekly' || frequency === 'quincenal') days = 14;
+  if (frequency === 'monthly' || frequency === 'mensual') days = 30;
+  date.setDate(date.getDate() + days);
+  const newDate = date.toISOString().slice(0, 10);
+
+  await supabase
+    .from('subscriptions')
+    .update({ next_renewal_date: newDate })
+    .eq('id', subscriptionId);
+
+  return NextResponse.json({ ok: true, next_renewal_date: newDate });
 }


### PR DESCRIPTION
## Summary
- connect portal page buttons to pause and skip API routes
- implement API stub to toggle subscription status
- implement subscription skip API that records skip and bumps renewal date

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*

------
https://chatgpt.com/codex/tasks/task_e_68a6326a14f483259fd0849fb6054c90